### PR TITLE
Bootstrap container image migration packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM arigaio/atlas:latest
+
+COPY migrations /migrations

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ docker pull arigaio/atlas
 
 Click [here](https://atlasgo.io/getting-started#installation) to read instructions for other platforms.
 
+## Creating a container image
+
+This repo comes with a bootstrapped Dockerfile to package the migrations as a container image.
+
+Build the container image:
+
+```console
+docker build -t atlas:local .
+```
+
 ## Common actions
 
 This repo comes with preconfigured `atlas.hcl` that defines a local MySQL-based dev environment named "local" which


### PR DESCRIPTION
Following the guide available at https://atlasgo.io/guides/deploying/image, I'd like to propose to include a basic Dockerfile in the template repository to easily package the migrations as container images.

I also included a couple of lines in the README to explicit this feature in the template repository.

Thanks a lot for making this repository public !